### PR TITLE
doFastLoad() exposes the workaround parameter

### DIFF
--- a/mrblib/build.rb
+++ b/mrblib/build.rb
@@ -791,10 +791,10 @@ def testSetup(widg)
 end
 
 #Load new classes if there are changes in files which should be hot loaded
-def doFastLoad(search=nil)
+#Hotloading is activated if workaround=false.
+def doFastLoad(search=nil, workaround=true)
     t1 = Time.new
     db  = PropertyDatabase.new
-    workaround = true
     lir = workaround || loadIR(search)
     if(lir)
         t2 = Time.new


### PR DESCRIPTION
Just a minor modification to the hotloading code that makes it possible to activate it from mruby-zest-build. It is fully backward compatible and also does not invalidate the instructions in mruby-zest-build/contributing.adoc.

The goal is to avoid messing up with code within submodules during development in mruby-zest-build, which I find rather error-prone.
