### PR TITLE
Ignore hidden files during hotload on Linux

### DIFF
--- a/mrblib/loader.rb
+++ b/mrblib/loader.rb
@@ -26,6 +26,8 @@ def loadIR(search=nil)
     different_file = false
     qml_data.each do |q|
         cname = q.gsub(".qml","").gsub(/.*\//, "")
+        # Ignore files starting with a dot (hidden files on Linux)
+        next if cname.start_with?('.')
         hash = File::Stat.new(q).ctime.to_s
         #hash  = `md5sum #{q}`
         q_ir = nil


### PR DESCRIPTION
Use case: ignore temporary files generated by emacs. Prior to this change any modification to a qml file with emacs while running zest in hotload mode would cause lots of error messages until the file is saved.